### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,17 +1,17 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-LIDERLite                     KEYWORD1
+LIDERLite	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setDelay                  KEYWORD2
-readDistance              KEYWORD2
-selectMultiplexerChannel  KEYWORD2
+setDelay	KEYWORD2
+readDistance	KEYWORD2
+selectMultiplexerChannel	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
-LIDERLite             KEYWORD2
+LIDERLite	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords